### PR TITLE
FP2: replace repowerd and remove workaround shell script

### DIFF
--- a/FP2/system/usr/bin/brighten_display_fp2_workaround.sh
+++ b/FP2/system/usr/bin/brighten_display_fp2_workaround.sh
@@ -1,1 +1,0 @@
-sleep 0.3 && echo 255 > /sys/class/leds/lcd-backlight/brightness


### PR DESCRIPTION
The cause of the screen brightness problem is that the brightness is set
before the screen is unblanked. Normally, repowerd calls the unity-
screen-compositor to unblank the screen via DBus asynchronously before
incrementally increase the brightness. The problem is that, on this
device, the brightness is ignored if the screen is blanked. So, there is
a race condition between the brightness is incremented to the max and
the screen being actually unblanked.

This commit makes this call synchronous, making sure that the screen will
be unblanked completely before the brightness is set.

This is the binary from repowerd version
2016.10.1+15.04.20161207-0ubuntu1peat2, grab the source code here:
https://launchpad.net/~peat-new/+archive/ubuntu/fp2-custom-test/+sourcepub/7355638/+listing-archive-extra

(Sorry for the new pull request. I forgot to put in source code's link in the commit message.)