### PR TITLE
common: add Upstart task for setting boot completion property.

### DIFF
--- a/common/system/etc/init/android-set-boot-completion-property.conf
+++ b/common/system/etc/init/android-set-boot-completion-property.conf
@@ -1,0 +1,12 @@
+description     "Set boot completion property in Android container"
+author          "Ratchanan Srirattanamet <peathot@hotmail.com>"
+
+start on desktop-session-start
+
+task
+
+script
+	setprop dev.bootcomplete 1
+	setprop sys.boot_completed 1
+	setprop init.svc.bootanim stopped
+end script


### PR DESCRIPTION
This script sets a number of Android properties which indicate if the
boot process has fully completed. Qualcomm's init system depends on
this property to carry some action.

For example, on Fairphone 2, this triggers init.qcom.post_boot.sh which
set a number of low power mode for CPU. This resulted in lower power
consumption and heat.